### PR TITLE
Site mainpage reviewed

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -5,34 +5,52 @@ date: "2017-01-22T18:20:00"
 aliases: [/home,/greetings]
 type: index
 ---
-    Welcome to the Coding Dojo site-to-be.
+Welcome to the Coding Dojo website
 
 ------------------------------------------------------------------------
+
+# Welcome
+The purpose of this website is to gather resources, sessions and stories from
+users around the world that the Coding Dojo website should provide to its user
+community.
+
+You can check the [Wish List](/WishList) and add ideas of what a Coding Dojo
+global website should provides.
+
+### About Coding Dojos
+To start off, a directory of who we are and what exactly are we doing:
+
+-   [What Is Coding Dojo](/WhatIsCodingDojo)
+-   [Coding Dojos](/CodingDojos)
+-   [Who's Who](/WhosWho)
+-   [Kata Catalogue](/KataCatalogue)
+-   [My First Dojo](/MyFirstDojo) (some pragmatic suggestions for how a
+    Dojo might work)
+
+Programme for a workshop at XP2010 - see [Kata Workshop](/KataWorkshop)
+
+
+# News
 
 ***JAN. 2,2017, New website.***
 
 Hi everyone,
 
-After some years frozen in time, we can again easily update the Coding Dojo website
-without any fear. Times changed and we have lots of information anywhere about katas and 
-coding dojos but it's still important to have a central point of information and that's
-why we updated this site. 
+After some years frozen in time, we can again easily update the Coding Dojo
+website without any fear. Times changed and we have lots of information anywhere
+about katas and coding dojos but it's still important to have a central point of
+information and that's why we updated this site.
 
-It will take some time to update the content, add new, remove deprecated pages, contact groups and
-so on, but it's started and in progress. It's not any more a wiki but a much simpler engine base on 
-static markdown pages. 
+It will take some time to update the content, add new, remove deprecated pages,
+contact groups and so on, but it's started and in progress. It's not any more a
+wiki but a much simpler engine base on static markdown pages.
 
-If you want to add something or help us with the cleaning: fork, clone, submit a PR and your
-ideas through issues to start the discussion. 
+If you want to add something or help us with the cleaning: fork, clone, submit a
+PR and your ideas through issues to start the discussion.
 
 Rui & Thomas
 
-
-
 ----------------
-
-
-
 
 ***SEPT. 2, 2012 / NEW UPDATE.***
 
@@ -63,24 +81,3 @@ from perfect. But eventually we'll make it work better.
 Yours,
 
 -- [Emmanuel Gaillot](/people/EmmanuelGaillot) .
-
-------------------------------------------------------------------------
-
-The purpose of this wiki is to gather user stories for what the Coding
-Dojo global web site should provide to its user community. The wiki will
-provide "scaffolding" while the site grows in functionality to meet
-these requirements.
-
--   [Wish List](/WishList) - if we could have anything we wanted, what
-    would we want from a Coding Dojo global website?
-
-To start off, a directory of who we are and what exactly are we doing:
-
--   [What Is Coding Dojo](/WhatIsCodingDojo)
--   [Coding Dojos](/CodingDojos)
--   [Who's Who](/WhosWho)
--   [Kata Catalogue](/KataCatalogue)
--   [My First Dojo](/MyFirstDojo) (some pragmatic suggestions for how a
-    Dojo might work)
-
-Programme for a workshop at XP2010 - see [Kata Workshop](/KataWorkshop)


### PR DESCRIPTION
* First, global information comes first. My guess would be that a lot of
  people arrives here to get information about What Is A Coding Dojo and
  it should stand first.
* In introduction, the website was still refered as a wiki.
* Welcome part has been re-arranged
* h1 and h3 titles added for more lisibility
* News section is now down the page