### PR TITLE
removed problematic wikipedia quote

### DIFF
--- a/content/kata/RomanNumerals.md
+++ b/content/kata/RomanNumerals.md
@@ -35,9 +35,6 @@ For a full description of how it works, take a look at [\[this useful reference 
 
 There is no need to be able to convert numbers larger than about 3000.  (The Romans themselves didn't tend to go any higher)
 
-Note that you can't write numerals like "IM" for 999. Wikipedia says:
-*Modern Roman numerals ... are written by expressing each digit separately starting with the left most digit and skipping any digit with a value of zero. To see this in practice, consider the ... example of 1990. In Roman numerals 1990 is rendered: 1000=M, 900=CM, 90=XC; resulting in MCMXC. 2008 is written as 2000=MM, 8=VIII; or MMVIII.*
-
 ## Part II
 
 Write a function to convert in the other direction, ie numeral to digit


### PR DESCRIPTION
the quote that is meant to be from wikipedia doesn't exist on the wikipedia page, nor does the provided quote invalidate `IM`, and neither does the linked how to resource