### PR TITLE
Fix formatting issue in NumberToLCD.md

### DIFF
--- a/content/kata/NumberToLCD.md
+++ b/content/kata/NumberToLCD.md
@@ -13,10 +13,12 @@ Goal: write a program that displays LCD style numbers.
 
 Write a program that given a number (with arbitrary number of digits), converts it into LCD style numbers using the following format:
 
+```
    _  _     _  _  _  _  _  
  | _| _||_||_ |_   ||_||_|  
- ||_  _|   | _||_|  ||_| _|  
-  
+ ||_  _|  | _||_|  ||_| _|  
+```
+ 
 (each digit is 3 lines high)
 
 Note: Please do *NOT* read the second part before completing the first. Part of the purpose of this kata is to make you  practice refactoring and adapting to changing requirements.
@@ -26,12 +28,16 @@ Note: Please do *NOT* read the second part before completing the first. Part of 
 Change your program to support variable width or height of the digits.
 For example for width = 3 and height = 2 the digit 2 will be:
 
+```
  ___
-      |
-      |
+    |
+    |
  ___
 |
-|___
+|
+ ___
+
+```
 
 This kata based on:
 https://github.com/coreyhaines/kata-number-to-led


### PR DESCRIPTION
Seen on: http://codingdojo.org/kata/NumberToLCD/ Markdown was collapsing the number examples... Added md code blocks to fix.

Before:
![before](https://cloud.githubusercontent.com/assets/4740018/26369467/fcfcb9fe-3fb1-11e7-850b-ab0cdaf2ad5d.png)

After:
![after](https://cloud.githubusercontent.com/assets/4740018/26369475/059b0b92-3fb2-11e7-98f6-6444eb761ac7.png)