### PR TITLE
new link to wordlist for kata anagram

### DIFF
--- a/content/kata/Anagram.md
+++ b/content/kata/Anagram.md
@@ -16,7 +16,7 @@ selfexplanatorycode.blogspot.com/2008/08/announcing-self-documenting-code.html
 
 Write a program that generates all two-word anagrams of the string
 "documenting". Here's a word list you might want to use:
-pragdave.pragprog.com/data/wordlist.txt.
+https://gist.githubusercontent.com/calvinmetcalf/084ab003b295ee70c8fc/raw/314abfdc74b50f45f3dbbfa169892eff08f940f2/wordlist.txt.
 
 ## Clues
 


### PR DESCRIPTION
The link to pragdave.pragprog.com was dead